### PR TITLE
Update Withdraw V2 when closing Vault TA

### DIFF
--- a/programs/casier/src/lib.rs
+++ b/programs/casier/src/lib.rs
@@ -473,12 +473,12 @@ pub mod casier {
                 ctx.accounts.token_program.to_account_info(),
                 anchor_spl::token::CloseAccount {
                     account: ctx.accounts.vault_ta.to_account_info(),
-                    destination: ctx.accounts.user_ta_owner.to_account_info(),
+                    destination: ctx.accounts.vault_ta_owner.to_account_info(),
                     authority: ctx.accounts.vault_ta.to_account_info(),
                 },
                 &[&[
                     ctx.accounts.mint.key().as_ref(),
-                    ctx.accounts.user_ta_owner.key().as_ref(),
+                    ctx.accounts.vault_ta_owner.key().as_ref(),
                     &[vault_bump],
                 ]],
             ))?;

--- a/programs/casier/src/state.rs
+++ b/programs/casier/src/state.rs
@@ -105,6 +105,9 @@ pub struct WithdrawV2<'info> {
     pub vault_ta: Account<'info, TokenAccount>,
     /// CHECK:
     #[account(mut)]
+    pub vault_ta_owner: AccountInfo<'info>,
+    /// CHECK:
+    #[account(mut)]
     pub burn_ta: UncheckedAccount<'info>,
     pub system_program: Program<'info, System>,
     pub token_program: Program<'info, Token>,

--- a/tests/casier.ts
+++ b/tests/casier.ts
@@ -509,7 +509,6 @@ describe("casier", () => {
         associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
         rent: SYSVAR_RENT_PUBKEY,
       })
-      .signers([user])
       .rpc();
 
     const burnTokenAccount = await provider.connection.getParsedAccountInfo(
@@ -577,7 +576,6 @@ describe("casier", () => {
         associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
         rent: SYSVAR_RENT_PUBKEY,
       })
-      .signers([user])
       .rpc();
 
     const burnTokenAccount = await provider.connection.getParsedAccountInfo(
@@ -656,7 +654,6 @@ describe("casier", () => {
         associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
         rent: SYSVAR_RENT_PUBKEY,
       })
-      .signers([userDest])
       .rpc();
 
     const userTAAmount = (await getAccount(provider.connection, userTa)).amount.toString();
@@ -816,7 +813,6 @@ describe("casier", () => {
         associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
         rent: SYSVAR_RENT_PUBKEY,
       })
-      .signers([user])
       .rpc();
 
     await afterChecks(mintIndex, vaultTa, locker, finalAmount, mint);

--- a/tests/casier.ts
+++ b/tests/casier.ts
@@ -498,11 +498,11 @@ describe("casier", () => {
         config: configPDA,
         locker,
         mint: mint,
-        
         admin: providerPk,
         userTa,
         userTaOwner: user.publicKey,
         vaultTa,
+        vaultTaOwner: user.publicKey,
         burnTa,
         systemProgram: SystemProgram.programId,
         tokenProgram: TOKEN_PROGRAM_ID,
@@ -566,11 +566,11 @@ describe("casier", () => {
         config: configPDA,
         locker,
         mint: mint,
-        
         admin: providerPk,
         userTa,
         userTaOwner: user.publicKey,
         vaultTa,
+        vaultTaOwner: user.publicKey,
         burnTa,
         systemProgram: SystemProgram.programId,
         tokenProgram: TOKEN_PROGRAM_ID,
@@ -616,6 +616,8 @@ describe("casier", () => {
       );
     
     const mint = mints[mintIndex];
+
+    const userFrom = users[userLockerFromIndex];
     
     const userDest = users[userDestIndex];
     const userTa = tokenAccounts[userDestIndex][mintIndex];
@@ -643,11 +645,11 @@ describe("casier", () => {
         config: configPDA,
         locker: lockerFrom,
         mint: mint,
-        
         admin: providerPk,
         userTa,
         userTaOwner: userDest.publicKey,
         vaultTa,
+        vaultTaOwner: userFrom.publicKey,
         burnTa,
         systemProgram: SystemProgram.programId,
         tokenProgram: TOKEN_PROGRAM_ID,
@@ -807,6 +809,7 @@ describe("casier", () => {
         userTa,
         userTaOwner: user.publicKey,
         vaultTa,
+        vaultTaOwner: user.publicKey,
         burnTa,
         systemProgram: SystemProgram.programId,
         tokenProgram: TOKEN_PROGRAM_ID,


### PR DESCRIPTION
- Update destination and seeds used when closing vault TA in Withdraw V2 as owner may differ between vault and user TAs